### PR TITLE
define CV_FOURCC as its replacement in newer versions of OpenCV

### DIFF
--- a/adcvApp/adcvSrc/NDPluginCVHelper.h
+++ b/adcvApp/adcvSrc/NDPluginCVHelper.h
@@ -31,6 +31,10 @@
 #ifdef NDCV_WITH_VIDEO
 #include <opencv2/video.hpp>
 #include <opencv2/videoio.hpp>
+    // For compatibility with newer versions of OpenCV
+    #ifndef CV_FOURCC
+    #define CV_FOURCC(first,second,third,fourth) cv::VideoWriter::fourcc(first,second,third,fourth)
+    #endif
 #endif
 
 // use standard and opencv namespaces


### PR DESCRIPTION
CV_FOURCC macro was replaced with `cv::VideoWriter::fourcc(first,second,third,fourth)` from [version 3.4](https://docs.opencv.org/3.4/dd/d9e/classcv_1_1VideoWriter.html#afec93f94dc6c0b3e28f4dd153bc5a7f0). As far as I can tell from our use of this plugin, this is all that's necessary for use with the Debian packaged version, currently 4.6.0 on Bookworm.